### PR TITLE
delete setSize upper bound to size

### DIFF
--- a/graphics.py
+++ b/graphics.py
@@ -763,7 +763,7 @@ class Text(GraphicsObject):
             raise GraphicsError(BAD_OPTION)
 
     def setSize(self, size):
-        if 5 <= size <= 36:
+        if 5 <= size:
             f,s,b = self.config['font']
             self._reconfig("font", (f,size,b))
         else:


### PR DESCRIPTION
During testing, I have found that the Text.setSize() function had an upper limit to font size of 35. After removing the if statement inside, I have tested sizes up to 500, and found no errors or artifacts. Therefore, I think that the limit should be deleted.